### PR TITLE
Closes #36. Adiciona devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,7 @@
+{
+  "image": "squidfunk/mkdocs-material:9",
+  "runArgs": ["-it", "-p=8000:8000"],
+  "workspaceMount": "source=${localWorkspaceFolder},target=/docs,type=bind",
+  "workspaceFolder": "/docs",
+  "postStartCommand": "mkdocs serve --dev-addr=0.0.0.0:8000"
+}


### PR DESCRIPTION
Para testar o código, é necessário que você o feche projeto, abra novamente e assim que abrir deverá aparecer uma caixa de texto com `Open in a container`, ou `Abrir em container`.

É necessário que se tenha instalado a extensão `devcontainer`.
É necessário que se tenha habilitado `Expose daemon` em seu Docker Desktop.